### PR TITLE
Add related blog links to slide out drawer

### DIFF
--- a/components/Drawer.tsx
+++ b/components/Drawer.tsx
@@ -9,21 +9,76 @@ import {
   Theme,
   useTheme,
   ListItemButton,
+  Divider,
+  Typography,
 } from "@mui/material"
 import HomeRoundedIcon from "@mui/icons-material/HomeRounded"
 import MenuRoundedIcon from "@mui/icons-material/MenuRounded"
 import CloseIcon from "@mui/icons-material/Close"
 import StarRoundedIcon from "@mui/icons-material/StarRounded"
+import ArticleIcon from "@mui/icons-material/Article"
 
 import { useState } from "react"
 import DarkMode from "./DarkMode"
 import { MaterialLink } from "./MaterialLink"
+import { MetadataType } from "../article_configs/process_articles"
+import { orderedIncludeBlogs } from "../article_configs/article_order_config"
+
+/**
+ * Find related blogs based on the top tag of the current article.
+ * Filters by top tag and orders according to article_order_config.ts.
+ */
+function getRelatedBlogs(
+  currentArticle: MetadataType | null,
+  allArticles: MetadataType[]
+): MetadataType[] {
+  if (!currentArticle || !currentArticle.tagIds || currentArticle.tagIds.length === 0) {
+    return []
+  }
+
+  // Get the top tag (first tag in the array).
+  const topTag = currentArticle.tagIds[0]
+
+  // Filter blogs that have the same top tag and are different from current article.
+  const relatedBlogs = allArticles.filter((article) => {
+    return (
+      article.articleType === "BLOG" &&
+      article.tagIds &&
+      article.tagIds.includes(topTag) &&
+      article.title !== currentArticle.title
+    )
+  })
+
+  // Order according to orderedIncludeBlogs config.
+  const orderedRelated = relatedBlogs.sort((a, b) => {
+    const aFileName = `${a.cardPageLink.split('/').pop()}.md`
+    const bFileName = `${b.cardPageLink.split('/').pop()}.md`
+    
+    const aIndex = orderedIncludeBlogs.indexOf(aFileName)
+    const bIndex = orderedIncludeBlogs.indexOf(bFileName)
+    
+    // If not found in order config, put at end.
+    const aOrder = aIndex === -1 ? 9999 : aIndex
+    const bOrder = bIndex === -1 ? 9999 : bIndex
+    
+    return aOrder - bOrder
+  })
+
+  // Return maximum of 5 related blogs.
+  return orderedRelated.slice(0, 5)
+}
 
 interface DrawerPropType {
   anchor?: "left" | "right"
+  currentArticle?: MetadataType | null
+  allArticles?: MetadataType[]
 }
 
-export default function Drawer({ anchor = "right" }: DrawerPropType) {
+export default function Drawer({ 
+  anchor = "right", 
+  currentArticle = null, 
+  allArticles = [] 
+}: DrawerPropType) {
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false)
 
   const toggleDrawer = () => {
@@ -37,6 +92,9 @@ export default function Drawer({ anchor = "right" }: DrawerPropType) {
     width: 400,
     [theme.breakpoints.down("md")]: { width: 300 },
   }
+
+  // Get related blogs.
+  const relatedBlogs = getRelatedBlogs(currentArticle, allArticles)
 
   let key: number = 0
   return (
@@ -73,11 +131,41 @@ export default function Drawer({ anchor = "right" }: DrawerPropType) {
               </ListItemButton>
             </ListItem>
 
-            {/* TODO(): Add related content */}
-            {/* <Divider sx={{ pt: 5 }} />
-            <ListItem key={key++} sx={{ fontWeight: "bold" }}>
-              Related
-            </ListItem> */}
+            {/* Related content section */}
+            {relatedBlogs.length > 0 && (
+              <>
+                <Divider sx={{ pt: 2, mb: 1 }} />
+                <ListItem key={key++} sx={{ fontWeight: "bold", pb: 0 }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: "bold", color: "text.secondary" }}>
+                    Related Blogs
+                  </Typography>
+                </ListItem>
+                {relatedBlogs.map((blog) => (
+                  <ListItem key={key++} disablePadding>
+                    <ListItemButton 
+                      to={blog.cardPageLink} 
+                      component={MaterialLink}
+                      onClick={toggleDrawer}
+                    >
+                      <ListItemText 
+                        primary={blog.title}
+                        primaryTypographyProps={{ 
+                          variant: "body2",
+                          sx: { 
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            display: "-webkit-box",
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: "vertical",
+                          }
+                        }}
+                      />
+                      <ArticleIcon sx={{ mr: 1, fontSize: "small" }} />
+                    </ListItemButton>
+                  </ListItem>
+                ))}
+              </>
+            )}
           </List>
         </Box>
       </SwipeableDrawer>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -4,12 +4,19 @@ import { Box, Container, Theme, Typography, useTheme } from "@mui/material"
 import DarkModeSwitch from "./DarkMode"
 import Drawer from "./Drawer"
 import { MaterialLink } from "./MaterialLink"
+import { MetadataType } from "../article_configs/process_articles"
 
 interface NavbarProps {
   containerWidth?: "xs" | "sm" | "md" | "lg" | "xl"
+  currentArticle?: MetadataType | null
+  allArticles?: MetadataType[]
 }
 
-export default function Navbar({ containerWidth = "md" }: NavbarProps) {
+export default function Navbar({ 
+  containerWidth = "md", 
+  currentArticle = null, 
+  allArticles = [] 
+}: NavbarProps) {
   const theme: Theme = useTheme()
 
   return (
@@ -63,7 +70,10 @@ export default function Navbar({ containerWidth = "md" }: NavbarProps) {
             }}
           >
             <DarkModeSwitch />
-            <Drawer />
+            <Drawer 
+              currentArticle={currentArticle} 
+              allArticles={allArticles}
+            />
           </Box>
         </Box>
       </Container>


### PR DESCRIPTION
Adds a "Related Blogs" section to the article drawer, displaying relevant articles based on the current blog's top tag and a predefined order.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed5e5f4b-0540-4418-977e-1adec009652e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ed5e5f4b-0540-4418-977e-1adec009652e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>