### PR TITLE
Add Google Photos-style brick layout for blog articles

### DIFF
--- a/components/BlogLayout.tsx
+++ b/components/BlogLayout.tsx
@@ -17,6 +17,7 @@ import AuthButton from "./AuthButton"
 import { isUserSignedIn } from "./AuthUtils"
 import BlogNavbar from "./BlogNavbar"
 import ExperienceCards from "./ExperienceCards"
+import BrickLayoutCards from "./BrickLayoutCards"
 import ExperienceCardsPlaceholder from "./ExperienceCardsPlaceholder"
 import FilterBar from "./FilterBar"
 import HiddenPreviewImage from "./HiddenPreviewImage"
@@ -76,9 +77,8 @@ export default function BlogLayout({ metadataProps }: BlogLayoutProps) {
           {/* Articles Section */}
           <Grid xs={12}>
             {isUserSignedIn(session) ? (
-              <ExperienceCards
+              <BrickLayoutCards
                 metadata={metadataProps}
-                useBackgroundImages={true}
               />
             ) : (
               <>

--- a/components/BrickLayoutCards.tsx
+++ b/components/BrickLayoutCards.tsx
@@ -1,3 +1,9 @@
+/**
+ * Text-less brick layout cards.
+ *
+ * Columns change based on screen size.
+*/
+
 import { Box, Typography } from "@mui/material"
 import { useEffect, useMemo, useState } from "react"
 import { filterDataConfig } from "../article_configs/filters_config"

--- a/components/BrickLayoutCards.tsx
+++ b/components/BrickLayoutCards.tsx
@@ -1,5 +1,4 @@
 import { Box, Typography } from "@mui/material"
-import { useRouter } from "next/router"
 import { useEffect, useMemo, useState } from "react"
 import { filterDataConfig } from "../article_configs/filters_config"
 import { MetadataType } from "../article_configs/process_articles"
@@ -14,7 +13,6 @@ export interface BrickLayoutCardsProps {
 }
 
 export default function BrickLayoutCards({ metadata }: BrickLayoutCardsProps) {
-  const router = useRouter()
   const [selected, setSelected] = useState<MetadataType[]>(metadata)
   const { selectedTags, setSelectedTags }: SelectFilterTagContextType =
     useSelectedFilterTagContext()
@@ -41,14 +39,13 @@ export default function BrickLayoutCards({ metadata }: BrickLayoutCardsProps) {
   return (
     <Box
       sx={{
-        display: "grid",
-        gridTemplateColumns: {
-          xs: "repeat(2, 1fr)",
-          sm: "repeat(3, 1fr)",
-          md: "repeat(4, 1fr)",
-          lg: "repeat(5, 1fr)",
+        columns: {
+          xs: 1,
+          sm: 2,
+          md: 3,
+          lg: 4,
         },
-        gap: 1.5,
+        columnGap: "12px",
         mb: 10,
       }}
     >
@@ -66,9 +63,8 @@ interface BrickCardProps {
 
 function BrickCard({ card, index }: BrickCardProps) {
   const [imageLoaded, setImageLoaded] = useState(false)
-  const [aspectRatio, setAspectRatio] = useState(1)
 
-  const heights = [200, 250, 300, 180, 220, 280, 320, 160, 240, 290]
+  const heights = [200, 250, 300, 180, 220, 280, 320, 160, 240, 290, 270, 190, 310, 230]
   const height = heights[index % heights.length]
 
   useEffect(() => {
@@ -76,7 +72,6 @@ function BrickCard({ card, index }: BrickCardProps) {
       const img = new Image()
       img.onload = () => {
         setImageLoaded(true)
-        setAspectRatio(img.width / img.height)
       }
       img.onerror = () => setImageLoaded(false)
       img.src = card.imagePath
@@ -89,6 +84,8 @@ function BrickCard({ card, index }: BrickCardProps) {
       to={card.cardPageLink}
       sx={{
         position: "relative",
+        display: "inline-block",
+        width: "100%",
         height: height,
         borderRadius: 2,
         overflow: "hidden",
@@ -100,6 +97,7 @@ function BrickCard({ card, index }: BrickCardProps) {
         backgroundRepeat: "no-repeat",
         backgroundColor: imageLoaded ? "transparent" : "grey.300",
         transition: "transform 0.2s ease-in-out",
+        breakInside: "avoid",
         "&:hover": {
           transform: "scale(1.02)",
           "& .hover-overlay": {

--- a/components/BrickLayoutCards.tsx
+++ b/components/BrickLayoutCards.tsx
@@ -1,0 +1,159 @@
+import { Box, Typography } from "@mui/material"
+import { useRouter } from "next/router"
+import { useEffect, useMemo, useState } from "react"
+import { filterDataConfig } from "../article_configs/filters_config"
+import { MetadataType } from "../article_configs/process_articles"
+import {
+  SelectFilterTagContextType,
+  useSelectedFilterTagContext,
+} from "../contexts/selectFilterTag"
+import { MaterialLink } from "./MaterialLink"
+
+export interface BrickLayoutCardsProps {
+  metadata: MetadataType[]
+}
+
+export default function BrickLayoutCards({ metadata }: BrickLayoutCardsProps) {
+  const router = useRouter()
+  const [selected, setSelected] = useState<MetadataType[]>(metadata)
+  const { selectedTags, setSelectedTags }: SelectFilterTagContextType =
+    useSelectedFilterTagContext()
+
+  useMemo(() => {
+    if (
+      selectedTags.length <= 0 ||
+      selectedTags.length >= filterDataConfig.length
+    ) {
+      setSelected(metadata)
+    } else {
+      setSelected(
+        metadata.filter((card: MetadataType) =>
+          card.tagIds?.some((cardTag: string) => selectedTags.includes(cardTag))
+        )
+      )
+    }
+
+    if (selectedTags.length >= filterDataConfig.length) {
+      setSelectedTags([])
+    }
+  }, [selectedTags])
+
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: {
+          xs: "repeat(2, 1fr)",
+          sm: "repeat(3, 1fr)",
+          md: "repeat(4, 1fr)",
+          lg: "repeat(5, 1fr)",
+        },
+        gap: 1.5,
+        mb: 10,
+      }}
+    >
+      {selected.map((card: MetadataType, index: number) => (
+        <BrickCard key={card.cardPageLink} card={card} index={index} />
+      ))}
+    </Box>
+  )
+}
+
+interface BrickCardProps {
+  card: MetadataType
+  index: number
+}
+
+function BrickCard({ card, index }: BrickCardProps) {
+  const [imageLoaded, setImageLoaded] = useState(false)
+  const [aspectRatio, setAspectRatio] = useState(1)
+
+  const heights = [200, 250, 300, 180, 220, 280, 320, 160, 240, 290]
+  const height = heights[index % heights.length]
+
+  useEffect(() => {
+    if (card.imagePath) {
+      const img = new Image()
+      img.onload = () => {
+        setImageLoaded(true)
+        setAspectRatio(img.width / img.height)
+      }
+      img.onerror = () => setImageLoaded(false)
+      img.src = card.imagePath
+    }
+  }, [card.imagePath])
+
+  return (
+    <Box
+      component={MaterialLink}
+      to={card.cardPageLink}
+      sx={{
+        position: "relative",
+        height: height,
+        borderRadius: 2,
+        overflow: "hidden",
+        cursor: "pointer",
+        textDecoration: "none",
+        backgroundImage: imageLoaded ? `url(${card.imagePath})` : "none",
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        backgroundRepeat: "no-repeat",
+        backgroundColor: imageLoaded ? "transparent" : "grey.300",
+        transition: "transform 0.2s ease-in-out",
+        "&:hover": {
+          transform: "scale(1.02)",
+          "& .hover-overlay": {
+            opacity: 1,
+          },
+        },
+      }}
+    >
+      <Box
+        className="hover-overlay"
+        sx={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: "rgba(0, 0, 0, 0.7)",
+          opacity: 0,
+          transition: "opacity 0.3s ease-in-out",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          padding: 2,
+          textAlign: "center",
+        }}
+      >
+        <Typography
+          variant="h6"
+          sx={{
+            color: "white",
+            fontWeight: "bold",
+            mb: 1,
+            fontSize: { xs: "0.9rem", sm: "1rem", md: "1.1rem" },
+            lineHeight: 1.2,
+          }}
+        >
+          {card.title}
+        </Typography>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "rgba(255, 255, 255, 0.9)",
+            fontSize: { xs: "0.75rem", sm: "0.8rem", md: "0.85rem" },
+            lineHeight: 1.3,
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitLineClamp: 4,
+            WebkitBoxOrient: "vertical",
+          }}
+        >
+          {card.cardDescription}
+        </Typography>
+      </Box>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary
- Replace traditional list layout with Google Photos-style masonry/brick layout for blog articles
- Add new BrickLayoutCards component with responsive column design
- Implement hover-to-reveal text overlay functionality

## Changes
- **BlogLayout.tsx**: Replace ExperienceCards with new BrickLayoutCards component
- **BrickLayoutCards.tsx**: New component implementing CSS multi-column masonry layout with varied card heights and hover effects

## Features
- Responsive columns: 1 (xs) → 2 (sm) → 3 (md) → 4 (lg)
- Natural masonry staggering using CSS columns
- Hover-activated text overlays with smooth transitions
- Varied card heights for organic brick-style arrangement
- Maintains existing filter functionality

## Test plan
- [ ] Verify masonry layout displays correctly across all screen sizes
- [ ] Confirm hover effects show/hide text overlays smoothly
- [ ] Test filter functionality works with new layout
- [ ] Ensure cards link to correct articles
- [ ] Validate responsive behavior on mobile, tablet, desktop